### PR TITLE
Travis: Do not explicitly request Linux distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: "perl"
 perl:
   - "5.10"
 
-dist: trusty
 sudo: required
 services:
   - docker


### PR DESCRIPTION
For consistency with the other eHive repositories, which use the default distro.