### PR TITLE
Remove Perl directives from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-language: "perl"
-
-perl:
-  - "5.10"
-
 sudo: required
 services:
   - docker


### PR DESCRIPTION
On the one hand perl-5.10 is not available under Xenial (which is in the process of becoming the default Travis build environment) so requesting it would cause a build failure, on the other we do not actually USE perl here - all the testing happens inside a Docker container. Just get rid of this.